### PR TITLE
Show typographically correct sharp symbol in the UI and accept it when finding frequency

### DIFF
--- a/source/panel/helper/freq_note.hpp
+++ b/source/panel/helper/freq_note.hpp
@@ -20,6 +20,9 @@ namespace zlpanel::freq_note {
     inline constexpr std::array kNoteNames = {
         "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"
     };
+    inline constexpr std::array kNoteNamesAlt = {
+        "C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"
+    };
     inline constexpr int kNotesInOctave = 12;
     inline constexpr double kA4Frequency = 440.0;
     inline constexpr int kA4SemitoneIndexFromC0 = 57;
@@ -33,7 +36,7 @@ namespace zlpanel::freq_note {
         const int total_semitones_from_c0 = rounded_semitones_from_a4 + kA4SemitoneIndexFromC0;
         const int octave = static_cast<int>(std::floor(static_cast<double>(total_semitones_from_c0) / kNotesInOctave));
         const int note_index = (total_semitones_from_c0 % kNotesInOctave + kNotesInOctave) % kNotesInOctave;
-        return kNoteNames[static_cast<size_t>(note_index)] + std::to_string(octave);
+        return kNoteNamesAlt[static_cast<size_t>(note_index)] + std::to_string(octave);
     }
 
     inline std::optional<double> getFrequencyFromNote(const std::string& note) {
@@ -57,6 +60,14 @@ namespace zlpanel::freq_note {
             if (kNoteNames[static_cast<size_t>(i)] == note_part) {
                 note_index = i;
                 break;
+            }
+        }
+        if (note_index == -1) {
+            for (int i = 0; i < static_cast<int>(kNoteNamesAlt.size()); ++i) {
+                if (kNoteNamesAlt[static_cast<size_t>(i)] == note_part) {
+                    note_index = i;
+                    break;
+                }
             }
         }
         if (note_index == -1) {

--- a/source/panel/helper/freq_note.hpp
+++ b/source/panel/helper/freq_note.hpp
@@ -63,14 +63,6 @@ namespace zlpanel::freq_note {
             }
         }
         if (note_index == -1) {
-            for (int i = 0; i < static_cast<int>(kNoteNamesAlt.size()); ++i) {
-                if (kNoteNamesAlt[static_cast<size_t>(i)] == note_part) {
-                    note_index = i;
-                    break;
-                }
-            }
-        }
-        if (note_index == -1) {
             return std::nullopt;
         }
 

--- a/source/panel/helper/freq_note.hpp
+++ b/source/panel/helper/freq_note.hpp
@@ -52,12 +52,17 @@ namespace zlpanel::freq_note {
         const std::string octave_part = note.substr(split_point);
 
         for (char& c : note_part) {
-            c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+            if (c >= 'a' && c <= 'g') {
+                c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+            }
         }
 
         int note_index = -1;
         for (int i = 0; i < static_cast<int>(kNoteNames.size()); ++i) {
-            if (kNoteNames[static_cast<size_t>(i)] == note_part) {
+            if (
+                kNoteNames[static_cast<size_t>(i)] == note_part ||
+                kNoteNamesAlt[static_cast<size_t>(i)] == note_part
+            ) {
                 note_index = i;
                 break;
             }


### PR DESCRIPTION
## Description
Use typographically correct C♯, D♯, F♯, G♯, A♯ alongside the simplified C#, D#, F#, G#, A# variants.

## Acknowledgments
*By submitting this pull request, I acknowledge and confirm the following:*

- [ ] If this is **not** a multilingual/localization support pull request, I confirm that this feature, fix, or change has been discussed and aligned upon in the repository's **Discussions** section prior to opening this PR.
- [x] I agree that all code contributed through this pull request is licensed under the **Apache-2.0 License**.
- [x] I certify that I am the sole author and legal owner of this code, or that I have the necessary rights and permissions to contribute it under the specified license without violating any third-party intellectual property.
- [x] I have manually reviewed this code and verified its functionality.